### PR TITLE
Feature/add improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +204,7 @@ dependencies = [
  "anyhow",
  "clap",
  "directories",
+ "dirs",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 directories = "5.0"
+dirs = "5.0"

--- a/README.md
+++ b/README.md
@@ -22,12 +22,7 @@ function my_hist --on-event fish_preexec --description "Track fish history in fi
 end
 ```
 
-4. Create the history directory:
-```bash
-mkdir -p ~/.local/share/fish
-```
-
-5. Restart your fish shell or run:
+4. Restart your fish shell or run:
 ```bash
 source ~/.config/fish/config.fish
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ The tool integrates with fish shell to provide quick access to your most frequen
 - `Ctrl+Shift+→`: Shows your second most frequent command
 - `Ctrl+Shift+←`: Shows your third most frequent command
 
+## How It Works
+
+The tool uses fish's built-in `history` command to get a complete list of all commands, including adjacent duplicates. This provides more accurate frequency counting than reading the history file directly, as the history file (`~/.local/share/fish/fish_history`) eliminates adjacent identical commands.
+
+The process:
+1. Executes `fish -c "history"` to get the complete command history
+2. Normalizes each command (removes extra spaces, quotes, etc.)
+3. Counts the frequency of each normalized command
+4. Sorts commands by frequency
+
 ## Debugging
 
 The tool includes a debug mode that can help diagnose issues with command frequency counting. To enable debug output, use the `-d` or `--debug` flag:
@@ -59,7 +69,6 @@ The debug output will show:
 
 ```
 === DEBUG OUTPUT ===
-History file: /home/user/.local/share/fish/fish_history
 Total commands processed: 1234
 Unique commands found: 567
 
@@ -73,16 +82,11 @@ Top 20 commands:
 
 ### Interpreting Debug Output
 
-1. **History File Location**: Shows the exact path of the fish history file being read. Verify this matches your system's configuration.
+1. **Total Commands Processed**: The total number of commands found in your history. This includes all commands, even adjacent duplicates.
 
-2. **Total Commands Processed**: The total number of commands found in your history file. If this number seems low, it might indicate:
-   - The history file is not being read correctly
-   - The history file is empty or truncated
-   - The file format is not being parsed correctly
+2. **Unique Commands Found**: The number of distinct commands after normalization. If this is much lower than total commands, it means many commands are duplicates.
 
-3. **Unique Commands Found**: The number of distinct commands after normalization. If this is much lower than total commands, it means many commands are duplicates.
-
-4. **Top 20 Commands**: Shows the most frequently used commands with their counts. This can help identify:
+3. **Top 20 Commands**: Shows the most frequently used commands with their counts. This can help identify:
    - If command normalization is working correctly
    - If certain commands are being counted multiple times
    - If expected commands are missing or have unexpected counts
@@ -100,18 +104,14 @@ Top 20 commands:
    - Look for similar commands that might be counted separately
 
 3. **Empty Output**: If no commands are shown:
-   - Verify the history file exists and is readable
-   - Check if the file format matches the expected YAML format
+   - Verify that `fish -c "history"` works in your shell
    - Ensure you have command history in fish
-
-## How It Works
-
-The tool reads your fish shell history file (`~/.local/share/fish/fish_history`), counts the frequency of each command, and allows you to quickly access them through keyboard shortcuts.
+   - Check if there are any permission issues
 
 ## Troubleshooting
 
 If the commands are not showing up:
 
 1. Make sure you have some command history in fish shell
-2. Check if the history file exists at `~/.local/share/fish/fish_history`
+2. Try running `fish -c "history"` to verify you can access the history
 3. Try running `most-frequent-commands analyze --top 10` to see if it can read your history 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,8 +1,5 @@
 use anyhow::{Context, Result};
-use directories::BaseDirs;
 use std::collections::HashMap;
-use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 
 pub struct CommandFrequency {
@@ -90,7 +87,7 @@ mod tests {
 
     #[test]
     fn test_command_frequency() {
-        // Create a test history string with more ls commands to ensure it's the most frequent
+        // Create a test history string
         let test_history = r#"1 ls
 2 ls -la
 3 cd
@@ -98,9 +95,7 @@ mod tests {
 5 git status
 6 ls
 7 cd
-8 cd
-9 ls
-10 ls"#;
+8 cd"#;
 
         // Create a mock CommandFrequency
         let mut commands = HashMap::new();
@@ -110,6 +105,15 @@ mod tests {
                 *commands.entry(normalized_cmd).or_insert(0) += 1;
             }
         }
+
+        // Debug output for the test
+        println!("\n=== TEST DEBUG OUTPUT ===");
+        println!("Commands in test history:");
+        for (cmd, count) in &commands {
+            println!("{}: {}", cmd, count);
+        }
+        println!("=== END TEST DEBUG ===\n");
+
         let frequency = CommandFrequency { commands };
 
         // Test get_most_frequent
@@ -118,10 +122,10 @@ mod tests {
         
         // Verify the order and counts
         assert_eq!(most_frequent[0].0, "ls");
-        assert_eq!(*most_frequent[0].1, 5);  // ls appears 5 times
+        assert_eq!(*most_frequent[0].1, 3);  // ls appears 3 times
         
         assert_eq!(most_frequent[1].0, "cd");
-        assert_eq!(*most_frequent[1].1, 2);  // cd appears 2 times
+        assert_eq!(*most_frequent[1].1, 3);  // cd appears 3 times
         
         assert_eq!(most_frequent[2].0, "ls -la");
         assert_eq!(*most_frequent[2].1, 1);  // ls -la appears 1 time

--- a/src/history.rs
+++ b/src/history.rs
@@ -95,7 +95,9 @@ mod tests {
 5 git status
 6 ls
 7 cd
-8 cd"#;
+8 cd
+9 ls
+10 git status"#;
 
         // Create a mock CommandFrequency
         let mut commands = HashMap::new();
@@ -122,12 +124,12 @@ mod tests {
         
         // Verify the order and counts
         assert_eq!(most_frequent[0].0, "ls");
-        assert_eq!(*most_frequent[0].1, 3);  // ls appears 3 times
+        assert_eq!(*most_frequent[0].1, 4);  // ls appears 4 times
         
         assert_eq!(most_frequent[1].0, "cd");
         assert_eq!(*most_frequent[1].1, 3);  // cd appears 3 times
         
-        assert_eq!(most_frequent[2].0, "ls -la");
-        assert_eq!(*most_frequent[2].1, 1);  // ls -la appears 1 time
+        assert_eq!(most_frequent[2].0, "git status");
+        assert_eq!(*most_frequent[2].1, 2);  // git status appears 1 time
     }
 } 

--- a/src/history.rs
+++ b/src/history.rs
@@ -3,6 +3,7 @@ use directories::BaseDirs;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 
 pub struct CommandFrequency {
     commands: HashMap<String, usize>,
@@ -11,48 +12,47 @@ pub struct CommandFrequency {
 impl CommandFrequency {
     pub fn new(debug: bool) -> Result<Self> {
         let mut commands = HashMap::new();
-        let history_file = Self::get_history_file()?;
+        let mut total_commands = 0;
 
-        if history_file.exists() {
-            let content = fs::read_to_string(&history_file)
-                .with_context(|| format!("Failed to read history file: {:?}", history_file))?;
+        // Get history from fish command
+        let output = Command::new("fish")
+            .arg("-c")
+            .arg("history")
+            .output()
+            .context("Failed to execute fish history command")?;
 
-            let mut current_cmd: Option<String> = None;
-            let mut total_commands = 0;
-            
-            for line in content.lines() {
-                if line.starts_with("- cmd: ") {
-                    if let Some(cmd) = current_cmd {
-                        let normalized_cmd = Self::normalize_command(&cmd);
-                        *commands.entry(normalized_cmd).or_insert(0) += 1;
-                        total_commands += 1;
-                    }
-                    current_cmd = Some(line[7..].to_string());
-                }
-            }
-            
-            // Don't forget the last command
-            if let Some(cmd) = current_cmd {
-                let normalized_cmd = Self::normalize_command(&cmd);
+        if !output.status.success() {
+            return Err(anyhow::anyhow!(
+                "Fish history command failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        let history = String::from_utf8(output.stdout)
+            .context("Failed to parse fish history output")?;
+
+        // Parse each line of history
+        for line in history.lines() {
+            if let Some(cmd) = line.splitn(2, ' ').nth(1) {
+                let normalized_cmd = Self::normalize_command(cmd);
                 *commands.entry(normalized_cmd).or_insert(0) += 1;
                 total_commands += 1;
             }
+        }
 
-            if debug {
-                println!("\n=== DEBUG OUTPUT ===");
-                println!("History file: {:?}", history_file);
-                println!("Total commands processed: {}", total_commands);
-                println!("Unique commands found: {}", commands.len());
-                
-                // Print top 20 commands for debugging
-                let mut debug_entries: Vec<_> = commands.iter().collect();
-                debug_entries.sort_by(|a, b| b.1.cmp(a.1));
-                println!("\nTop 20 commands:");
-                for (i, (cmd, count)) in debug_entries.iter().take(20).enumerate() {
-                    println!("{}. {} ({} times)", i + 1, cmd, count);
-                }
-                println!("=== END DEBUG ===\n");
+        if debug {
+            println!("\n=== DEBUG OUTPUT ===");
+            println!("Total commands processed: {}", total_commands);
+            println!("Unique commands found: {}", commands.len());
+            
+            // Print top 20 commands for debugging
+            let mut debug_entries: Vec<_> = commands.iter().collect();
+            debug_entries.sort_by(|a, b| b.1.cmp(a.1));
+            println!("\nTop 20 commands:");
+            for (i, (cmd, count)) in debug_entries.iter().take(20).enumerate() {
+                println!("{}. {} ({} times)", i + 1, cmd, count);
             }
+            println!("=== END DEBUG ===\n");
         }
 
         Ok(Self { commands })
@@ -68,16 +68,62 @@ impl CommandFrequency {
         cmd.to_string()
     }
 
-    fn get_history_file() -> Result<PathBuf> {
-        let base_dirs = BaseDirs::new().context("Failed to get base directories")?;
-        let mut path = PathBuf::from(base_dirs.home_dir());
-        path.push(".local/share/fish/fish_history");
-        Ok(path)
-    }
-
     pub fn get_most_frequent(&self, count: usize) -> Vec<(&String, &usize)> {
         let mut entries: Vec<_> = self.commands.iter().collect();
         entries.sort_by(|a, b| b.1.cmp(a.1));
         entries.into_iter().take(count).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_command() {
+        assert_eq!(CommandFrequency::normalize_command("  ls  "), "ls");
+        assert_eq!(CommandFrequency::normalize_command("ls -la"), "ls -la");
+        assert_eq!(CommandFrequency::normalize_command("  ls   -la  "), "ls -la");
+        assert_eq!(CommandFrequency::normalize_command("\"ls -la\""), "ls -la");
+        assert_eq!(CommandFrequency::normalize_command("'ls -la'"), "ls -la");
+    }
+
+    #[test]
+    fn test_command_frequency() {
+        // Create a test history string with more ls commands to ensure it's the most frequent
+        let test_history = r#"1 ls
+2 ls -la
+3 cd
+4 ls
+5 git status
+6 ls
+7 cd
+8 cd
+9 ls
+10 ls"#;
+
+        // Create a mock CommandFrequency
+        let mut commands = HashMap::new();
+        for line in test_history.lines() {
+            if let Some(cmd) = line.splitn(2, ' ').nth(1) {
+                let normalized_cmd = CommandFrequency::normalize_command(cmd);
+                *commands.entry(normalized_cmd).or_insert(0) += 1;
+            }
+        }
+        let frequency = CommandFrequency { commands };
+
+        // Test get_most_frequent
+        let most_frequent = frequency.get_most_frequent(3);
+        assert_eq!(most_frequent.len(), 3);
+        
+        // Verify the order and counts
+        assert_eq!(most_frequent[0].0, "ls");
+        assert_eq!(*most_frequent[0].1, 5);  // ls appears 5 times
+        
+        assert_eq!(most_frequent[1].0, "cd");
+        assert_eq!(*most_frequent[1].1, 2);  // cd appears 2 times
+        
+        assert_eq!(most_frequent[2].0, "ls -la");
+        assert_eq!(*most_frequent[2].1, 1);  // ls -la appears 1 time
     }
 } 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,18 @@
-use clap::Parser;
+use clap::{Parser, Subcommand, Args};
 use anyhow::Result;
 mod history;
 
 /// A command-line tool to analyze and display frequently used commands
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-enum Args {
-    /// Analyze and display most frequent commands
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Analyze command history and show most frequent commands
     Analyze {
         /// Number of top commands to show
         #[arg(short, long, default_value_t = 10)]
@@ -16,10 +22,11 @@ enum Args {
         #[arg(short, long)]
         debug: bool,
     },
-    /// Get the nth most frequent command
+    
+    /// Get a specific command by its index in the frequency list
     Get {
         /// Index of the command to get (0-based)
-        #[arg(short, long, default_value_t = 0)]
+        #[arg(short, long)]
         index: usize,
         
         /// Enable debug output
@@ -29,10 +36,10 @@ enum Args {
 }
 
 fn main() -> Result<()> {
-    let args = Args::parse();
+    let args = Cli::parse();
 
-    match args {
-        Args::Analyze { top, debug } => {
+    match args.command {
+        Commands::Analyze { top, debug } => {
             let frequency = history::CommandFrequency::new(debug)?;
             let most_frequent = frequency.get_most_frequent(top);
             
@@ -41,7 +48,7 @@ fn main() -> Result<()> {
                 println!("{}. {} (used {} times)", i + 1, cmd, count);
             }
         }
-        Args::Get { index, debug } => {
+        Commands::Get { index, debug } => {
             let frequency = history::CommandFrequency::new(debug)?;
             let most_frequent = frequency.get_most_frequent(index + 1);
             

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand, Args};
+use clap::{Parser, Subcommand};
 use anyhow::Result;
 mod history;
 


### PR DESCRIPTION
Went from analyzing the built-in fish history to custom_history which does no deduplication. This was also discussed here https://github.com/fish-shell/fish-shell/issues/5938 and also here https://github.com/fish-shell/fish-shell/issues/2398

I think the command is interesting. But most interesting is, that I do not understand rust at all but could set this up using cursor. Now I will take some time to understand the implementation.